### PR TITLE
fix: Add input=false flag to prevent TFC blockage

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -34,9 +34,8 @@ jobs:
           workspaces { name = "${{ secrets.LICENCEPLATE }}-${{ env.environment }}-backend" }
           EOF
 
-
-          terraform init -backend-config=backend.hcl
-          terraform destroy -auto-approve
+          terraform init -backend-config=backend.hcl -input=false
+          terraform destroy -auto-approve -input=false
 
       - name: destroying front-end
         run: |
@@ -46,5 +45,5 @@ jobs:
           workspaces { name = "${{ secrets.LICENCEPLATE }}-${{ env.environment }}-frontend" }
           EOF
 
-          terraform init -backend-config=backend.hcl
-          terraform destroy -auto-approve
+          terraform init -backend-config=backend.hcl -input=false
+          terraform destroy -auto-approve -input=false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,8 +43,9 @@ jobs:
           organization = "${{ env.organization }}"
           workspaces { name = "${{ secrets.LICENCEPLATE }}-${{ env.environment }}-backend" }
           EOF
-          terraform init -backend-config=backend.hcl
-          terraform plan
+          terraform init -backend-config=backend.hcl -input=false
+          terraform plan -input=false
+
       - name: Building front-end and deploying Frontend using terraform
         run: |
           cd server
@@ -56,5 +57,5 @@ jobs:
           organization = "${{ env.organization }}"
           workspaces { name = "${{ secrets.LICENCEPLATE }}-${{ env.environment }}-frontend" }
           EOF
-          terraform init -backend-config=backend.hcl
-          terraform plan
+          terraform init -backend-config=backend.hcl -input=false
+          terraform plan -input=false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,8 +40,8 @@ jobs:
           organization = "${{ env.organization }}"
           workspaces { name = "${{ secrets.LICENCEPLATE }}-${{ env.environment }}-backend" }
           EOF
-          terraform init -backend-config=backend.hcl
-          terraform apply -auto-approve
+          terraform init -backend-config=backend.hcl -input=false
+          terraform apply -auto-approve -input=false
           
       - name: Building front-end and deploying Frontend using terraform
         run: |
@@ -54,5 +54,5 @@ jobs:
           organization = "${{ env.organization }}"
           workspaces { name = "${{ secrets.LICENCEPLATE }}-${{ env.environment }}-frontend" }
           EOF
-          terraform init -backend-config=backend.hcl
-          terraform apply -auto-approve
+          terraform init -backend-config=backend.hcl -input=false
+          terraform apply -auto-approve -input=false


### PR DESCRIPTION
# Context
We want to avoid blockage on the Terraform cloud runner. 
For that we've added on all terraform reltaed command the flag `-input=false`

## Changes
- [x] add the flag on all terraform commands : `-input=false`

## Tests
- [x] Run all the command with this flag on my local terraform